### PR TITLE
Update list name if it is changed by another client

### DIFF
--- a/src/components/financialLists/financialLists.html
+++ b/src/components/financialLists/financialLists.html
@@ -88,7 +88,7 @@
           </a>
         </td>
         <td class="table-body__cell hidden-xs">{{value.changeDate | date:'d-MMM-yyyy h:mm a'}}</td>
-        <td class="table-body__cell hidden-xs">{{value.modifiedByName}}</td>
+        <td class="table-body__cell hidden-xs">{{value.modifiedByName.$value}}</td>
         <td class="table-header__cell">
           <div ng-hide="$ctrl.myRole !== 'RiseAdmin'" class="btn-group" uib-dropdown is-open="status.isopen">
             <button id="single-button" type="button" class="btn btn-xs btn-default" uib-dropdown-toggle ng-disabled="disabled">

--- a/src/components/financialLists/financial_list_list.service.js
+++ b/src/components/financialLists/financial_list_list.service.js
@@ -14,16 +14,16 @@ class financialListListService {
         return snap.val().modifiedBy;
       } )
       .then( ( modBy ) => {
-        return $firebaseObject( root.child( `users/${modBy}/name` ) ).$loaded();
-      } )
-      .then( ( userNameObject ) => {
         let listObject = $firebaseObject.$extend( {
           $$defaults: {
-            modifiedByName: userNameObject.$value
+            modifiedByName: $firebaseObject( root.child( `users/${modBy}/name` ) )
           }
         } );
 
         return new listObject( root.child( `lists/${key}` ) );
+      } )
+      .catch( ( err ) => {
+        console.error( err );
       } );
     }
 

--- a/src/components/financialLists/financial_list_list.service.js
+++ b/src/components/financialLists/financial_list_list.service.js
@@ -1,31 +1,30 @@
 class financialListListService {
-  constructor( $window, $firebaseArray ) {
+  constructor( $window, $firebaseArray, $firebaseObject ) {
     "ngInject";
 
     const root = $window.firebase.database().ref(),
       listData = $firebaseArray.$extend( {
         $$added( snap ) {
-          return createEntryForKey( snap.getKey() );
+          return createListObject( snap.getKey() );
         }
       } );
 
-    function createEntryForKey( key ) {
-      return getListDetails()
-      .then( ( details ) => {
-        return getUserName( details );
+    function createListObject( key ) {
+      return root.child( `lists/${key}` ).once( "value" ).then( ( snap ) => {
+        return snap.val().modifiedBy;
+      } )
+      .then( ( modBy ) => {
+        return $firebaseObject( root.child( `users/${modBy}/name` ) ).$loaded();
+      } )
+      .then( ( userNameObject ) => {
+        let listObject = $firebaseObject.$extend( {
+          $$defaults: {
+            modifiedByName: userNameObject.$value
+          }
+        } );
+
+        return new listObject( root.child( `lists/${key}` ) );
       } );
-
-      function getListDetails() {
-        return root.child( `lists/${key}` ).once( "value" ).then( ( snap ) => {
-          return Object.assign( {}, { $id: key }, snap.val() );
-        } );
-      }
-
-      function getUserName( details ) {
-        return root.child( `users/${details.modifiedBy}` ).once( "value" ).then( ( snap ) => {
-          return Object.assign( details, { modifiedByName: snap.val().name } );
-        } );
-      }
     }
 
     return {


### PR DESCRIPTION
This implements the $firebaseArray differently so that each element in
the array is a $firebaseObject which will watch for changes to the db.

Ideally the user name (modified by) would also get updated if the
/users/[key]/name field is modified in the db.  Unfortunately $$defaults
won't accept a thenable.

@settinghead please review
@Rise-Vision/delivery fyi