### PR TITLE
Don't show loading spinner on empty search result

### DIFF
--- a/src/components/displays/displays.controller.js
+++ b/src/components/displays/displays.controller.js
@@ -9,6 +9,7 @@ class DisplaysController {
     this.displayValidations = displayValidationService.results;
     this.errorMessage = "";
     this.$onInit = () => {
+      this.loading = true;
       _loadMyRole();
       _populateDisplays();
     };
@@ -102,6 +103,7 @@ class DisplaysController {
 
       _populateDisplays = $async( async() => {
         this.displayList = await displayListService.getMyDisplays( );
+        this.loading = false;
       } );
 
     function _outputErr( msg, e ) {

--- a/src/components/displays/displays.html
+++ b/src/components/displays/displays.html
@@ -62,8 +62,8 @@
         </tr>
       </thead>
 
-      <div ng-if="!$ctrl.displayList.length" us-spinner></div>
-      <tbody ng-if="$ctrl.displayList.length" class="table-body">
+      <div ng-if="$ctrl.loading" us-spinner></div>
+      <tbody ng-if="!$ctrl.loading" class="table-body">
 
         <tr class="table-body__row" ng-repeat="display in $ctrl.displayList">
           <td class="table-body__cell">


### PR DESCRIPTION
Show loading spinner only on initial load
@stulees / @settinghead  please review.  Previous change showed loading spinner whenever displaylist length was 0 but that ends up showing a spinner incorrectly when performing a search.