### PR TITLE
Fix last instrument result from being covered by footer [stage-2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "normalize.css": "^4.2.0",
     "q": "^1.4.1",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.4.0",
-    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.88",
+    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.99",
     "sortablejs": "^1.5.0-rc1"
   },
   "devDependencies": {

--- a/src/components/instruments/instruments.html
+++ b/src/components/instruments/instruments.html
@@ -89,6 +89,7 @@
           </tbody>
         </table>
       </div><!--panel-->
+      <div class="padding-lg-vertical"></div>
     </div>
   </div> <!--addInstruments-->
 


### PR DESCRIPTION
- Update `rv-common-style` to latest release to leverage padding utility classes
- Add additional padding (empty content) after the table to compensate for the floating buttons height