### PR TITLE
Revert common-style and use different padding class [stage-2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "normalize.css": "^4.2.0",
     "q": "^1.4.1",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git#1.4.0",
-    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.99",
+    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.88",
     "sortablejs": "^1.5.0-rc1"
   },
   "devDependencies": {

--- a/src/components/instruments/instruments.html
+++ b/src/components/instruments/instruments.html
@@ -89,7 +89,7 @@
           </tbody>
         </table>
       </div><!--panel-->
-      <div class="padding-lg-vertical"></div>
+      <div class="padding-large"></div>
     </div>
   </div> <!--addInstruments-->
 


### PR DESCRIPTION
- Latest common-style release 1.3.99 breaks layout of instrument list row item select box, revert back to stable release for financial selector 1.3.88
- Use different padding class to apply previous fix for additional padding (empty content) after the table to compensate for the floating buttons height