### PR TITLE
Add mailto link to invite user success modal

### DIFF
--- a/src/components/display_users/invite_success.controller.js
+++ b/src/components/display_users/invite_success.controller.js
@@ -15,6 +15,8 @@ class inviteSuccessController {
     let _populateInvite = $async( async () => {
       try {
         ctrl.email = decodeForFirebaseProp( ctrl.userId );
+        ctrl.mailTo = `mailto:${ctrl.userId}?subject=${encodeURIComponent( "Rise Financial Selector - I've added you as a User for Display " + ctrl.displayId )}&body=${encodeURIComponent( "You can now manage the Financial Instruments for the " + ctrl.displayId + " Display. Just sign in at https://selector.risevision.com using USERID as your username.\n\nIf USERID is a Google Account just select Log in with Google.\n\nIf USERID is not a Google Account you'll need to sign up and create your password first if you haven't already. You can do that here, https://selector.risevision.com/signup.\n\nThanks,\n\n" )}`;
+        ctrl.mailTo = ctrl.mailTo.replace( /USERID/g, ctrl.userId );
       } catch ( e ) {
         ctrl.errorMessage = `failed to load invite: ${e.message}`;
         console.error( e );

--- a/src/components/display_users/invite_success.html
+++ b/src/components/display_users/invite_success.html
@@ -6,11 +6,11 @@
   <error-message message="$ctrl.errorMessage"></error-message>
 
   <div style="padding:20px;" class="text-center">
-    <p>An invitation email for display
-      <strong>{{ $ctrl.displayId }}</strong>
-      was sent to
-      <strong>{{ $ctrl.email }}</strong>.
+    <p>
+      <strong>{{ $ctrl.email }}</strong> is now a User of the 
+      <strong>{{ $ctrl.displayId }}</strong> Display
     </p>
+    <a href="{{ $ctrl.mailTo }}" class="btn btn-primary">Send invitation email</a>
     <button class="btn btn-default" id="invite-success-ok-button" ng-click="$ctrl.ok()">OK</button>
   </div>
 


### PR DESCRIPTION
@stulees @settinghead If you have a mail client that is set up to handle mailto links please confirm this works:

```
mailto:test%40test.com?subject=Rise%20Financial%20Selector%20-%20I%27ve%20added%20you%20as%20a%20User%20for%20Display%20G6B7ET3EHGD4&body=You%20can%20now%20manage%20the%20Financial%20Instruments%20for%20the%20G6B7ET3EHGD4%20Display.%20Just%20sign%20in%20at%20https%3A%2F%2Fselector.risevision.com%20using%20test%40test%2Ecom%20as%20your%20username.%0A%0AIf%20test%40test%2Ecom%20is%20a%20Google%20Account%20just%20select%20Log%20in%20with%20Google.%0A%0AIf%20test%40test%2Ecom%20is%20not%20a%20Google%20Account%20you%27ll%20need%20to%20sign%20up%20and%20create%20your%20password%20first%20if%20you%20haven%27t%20already.%20You%20can%20do%20that%20here%2C%20https%3A%2F%2Fselector.risevision.com%2Fsignup.%0A%0AThanks%2C%0A%0A
```